### PR TITLE
Password Error Fix

### DIFF
--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -7,6 +7,7 @@ export class UpdateUserDto {
 
   @IsNotEmpty()
   roles: string[];
+  oldPassword?: string;
   password?: string;
   isActive?: boolean;
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -10,7 +10,7 @@ import Contact from '../crm/entities/contact.entity';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { UserListDto } from './dto/user-list.dto';
 import { getPersonFullName } from '../crm/crm.helpers';
-
+import * as bcrypt from "bcrypt";
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import { CreateUserDto } from './dto/create-user.dto';
 import { CreateUserResponseDto } from './dto/create-user-response.dto';
@@ -150,6 +150,15 @@ export class UsersService {
 
   async update(data: UpdateUserDto): Promise<UserListDto> {
     const _user = await this.findOne(data.id);
+
+    if(data.oldPassword) {
+      const oldPassword = await (await this.findByName(_user.username)).password;
+      const isSame = bcrypt.compareSync(data.oldPassword, oldPassword)
+      if (!isSame) {
+        throw new HttpException("Old Password Is Incorrect", 406);
+      }
+    }
+
     const update: QueryDeepPartialEntity<User> = {
       roles: data.roles,
       isActive: data.isActive ? data.isActive : _user.isActive,


### PR DESCRIPTION
# Ticket No
- ...

# Summary of changes
- Added logic to check if the password in the database matches the old password user entered

# How should this be tested? [Screenshots, Video or Type instructions]
- When users try to change their password through the settings menu, they will be prompted to enter their old password too
![Screen Shot 2021-06-28 at 11 47 24 AM](https://user-images.githubusercontent.com/68650343/123609205-22cb0300-d808-11eb-9cd9-ffc2e4289782.png)

- In the scenario that the user has entered the wrong password, an error message will pop up
![Screen Shot 2021-06-28 at 11 48 54 AM](https://user-images.githubusercontent.com/68650343/123609179-1c3c8b80-d808-11eb-851d-c4841530df2c.png)


# Notes for reviewers
- I investigated the error that admins would get when trying to activate a member's account and set a password. What I gathered was that this error only came about when there is already an active user with the same email. So with the elimination of duplicate users, this will not be an issue.
- This PR satisfies `#75 As a user, I'd like password reset errors fixed and show appropriate messages`

# Out of scope
-  none

