### PR TITLE
Refactor issue 94 and separate services from endpoints

### DIFF
--- a/src/crm/addresses.service.ts
+++ b/src/crm/addresses.service.ts
@@ -1,5 +1,6 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import SearchDto from 'src/shared/dto/search.dto';
 import { hasValue } from 'src/utils/validation';
 import GooglePlaceDto from 'src/vendor/google-place.dto';
 import { GoogleService } from 'src/vendor/google.service';
@@ -8,43 +9,60 @@ import Address from './entities/address.entity';
 
 @Injectable()
 export class AddressesService {
-    constructor(
-        @InjectRepository(Address) private readonly repository: Repository<Address>,
-        private googleService: GoogleService,
-    ){}
+  constructor(
+    @InjectRepository(Address) private readonly repository: Repository<Address>,
+    private googleService: GoogleService,
+  ) {}
 
-    async create(data: Address): Promise<Address> {
-        let place: GooglePlaceDto;
-        if (hasValue(data.placeId)) {
-            place = await this.googleService.getPlaceDetails(
-                data.placeId,
-            );
-          }
+  async create(data: Address): Promise<Address> {
+    let place: GooglePlaceDto;
+    if (hasValue(data.placeId)) {
+      place = await this.googleService.getPlaceDetails(data.placeId);
+    }
 
-          const getIsPrimary = await this.repository.find({
-            where: [{ contactId: data.contactId, isPrimary: true }],
-          });
-      
-          if (data.isPrimary === true) {
-            if (getIsPrimary.length > 0) {
-              await getIsPrimary.map((it) => {
-                const addresses = { ...it, isPrimary: false };
-                this.repository.save(addresses);
-              });
-            }
-          } else {
-            if (getIsPrimary.length < 1) {
-              data.isPrimary = true;
-            } else if (getIsPrimary.length > 1) {
-              await getIsPrimary.map((it) => {
-                const addresses = { ...it, isPrimary: false };
-                data.isPrimary = true;
-                this.repository.save(addresses);
-              });
-            }
-          }
-          //Get new Address details
-          const newAddress = {...data, ...place}
-        return await this.repository.save(newAddress);
+    const getIsPrimary = await this.repository.find({
+      where: [{ contactId: data.contactId, isPrimary: true }],
+    });
+
+    if (data.isPrimary === true) {
+      if (getIsPrimary.length > 0) {
+        await getIsPrimary.map((it) => {
+          const addresses = { ...it, isPrimary: false };
+          this.repository.save(addresses);
+        });
       }
+    } else {
+      if (getIsPrimary.length < 1) {
+        data.isPrimary = true;
+      } else if (getIsPrimary.length > 1) {
+        await getIsPrimary.map((it) => {
+          const addresses = { ...it, isPrimary: false };
+          data.isPrimary = true;
+          this.repository.save(addresses);
+        });
+      }
+    }
+    //Get new Address details
+    const newAddress = { ...data, ...place };
+    return await this.repository.save(newAddress);
+  }
+
+  async findAll(req: SearchDto): Promise<Address[]> {
+    return await this.repository.find({
+      skip: req.skip,
+      take: req.limit,
+    });
+  }
+
+  async update(data: Address): Promise<Address> {
+    return await this.repository.save(data);
+  }
+
+  async findOne(id: number): Promise<Address> {
+    return await this.repository.findOne(id);
+  }
+
+  async delete(id: number) {
+    return await this.repository.delete(id);
+  }
 }

--- a/src/crm/contollers/addresses.controller.spec.ts
+++ b/src/crm/contollers/addresses.controller.spec.ts
@@ -1,0 +1,49 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DeleteResult } from 'typeorm';
+import { AddressesService } from '../addresses.service';
+import Address from '../entities/address.entity';
+import { AddressesController } from './addresses.controller';
+
+describe('Addresses Controller', () => {
+  let controller: AddressesController;
+
+  let mockAddressesService = {
+    create: jest.fn((it) => new Address()),
+    update: jest.fn((it) => new Address()),
+    delete: jest.fn((it) => new Address()),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AddressesController],
+      providers: [AddressesService],
+    })
+      .overrideProvider(AddressesService)
+      .useValue(mockAddressesService)
+      .compile();
+
+    controller = module.get<AddressesController>(AddressesController);
+  });
+
+  it('Should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('Should create an address', async () => {
+    const data: Address = new Address();
+    const result = await controller.create(data);
+    expect(result).toEqual(expect.any(Address));
+  });
+
+  it('Should update and address', async () => {
+    const data: Address = new Address();
+    const result = await controller.update(data);
+    expect(result).toEqual(expect.any(Address));
+  });
+
+  it('Should delete an address', async () => {
+    const id = Math.floor(Math.random() * 100);
+    const result = await controller.remove(id);
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/crm/contollers/addresses.controller.ts
+++ b/src/crm/contollers/addresses.controller.ts
@@ -11,9 +11,7 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { InjectRepository } from '@nestjs/typeorm';
 import Address from '../entities/address.entity';
-import { Repository } from 'typeorm';
 import SearchDto from '../../shared/dto/search.dto';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { AddressesService } from '../addresses.service';
@@ -24,18 +22,11 @@ import { SentryInterceptor } from 'src/utils/sentry.interceptor';
 @ApiTags('Crm Addresses')
 @Controller('api/crm/addresses')
 export class AddressesController {
-  constructor(
-    @InjectRepository(Address) private readonly repository: Repository<Address>,
-
-    private readonly service:AddressesService
-  ) {}
+  constructor(private readonly service: AddressesService) {}
 
   @Get()
   async findAll(@Query() req: SearchDto): Promise<Address[]> {
-    return await this.repository.find({
-      skip: req.skip,
-      take: req.limit,
-    });
+    return this.service.findAll(req);
   }
 
   @Post()
@@ -45,16 +36,16 @@ export class AddressesController {
 
   @Put()
   async update(@Body() data: Address): Promise<Address> {
-    return await this.repository.save(data);
+    return await this.service.update(data);
   }
 
   @Get(':id')
   async findOne(@Param('id') id: number): Promise<Address> {
-    return await this.repository.findOne(id);
+    return await this.service.findOne(id);
   }
 
   @Delete(':id')
   async remove(@Param('id') id: number): Promise<void> {
-    await this.repository.delete(id);
+    await this.service.delete(id);
   }
 }

--- a/src/crm/contollers/emails.controller.spec.ts
+++ b/src/crm/contollers/emails.controller.spec.ts
@@ -1,0 +1,57 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DeleteResult } from 'typeorm';
+import { EmailService } from '../emails.service';
+import Email from '../entities/email.entity';
+import { EmailCategory } from '../enums/emailCategory';
+import { EmailsController } from './emails.controller';
+
+describe('EmailsController', () => {
+  let controller: EmailsController;
+
+  let mockEmailService = {
+    create: jest.fn((it) => new Email()),
+    update: jest.fn((it) => new Email()),
+    delete: jest.fn((it) => new Email()),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [EmailsController],
+      providers: [EmailService],
+    })
+      .overrideProvider(EmailService)
+      .useValue(mockEmailService)
+      .compile();
+
+    controller = module.get<EmailsController>(EmailsController);
+  });
+
+  it('Should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('Should create an email', async () => {
+    const data: Email = new Email();
+    const result = await controller.create(data);
+    expect(result).toEqual(expect.any(Email));
+  });
+
+  it('Should update an Email', async () => {
+    // const newEmail: Email = {
+    //   id: Math.floor(Math.random() * 100),
+    //   category: EmailCategory.Personal,
+    //   value: 'test@email.com',
+    //   isPrimary: true,
+    //   contactId: Math.floor(Math.random() * 100),
+    // };
+    const data: Email = new Email();
+    const result = await controller.update(data);
+    expect(result).toEqual(expect.any(Email));
+  });
+
+  it('Should delete an Email', async () => {
+    const myId = Math.floor(Math.random() * 100);
+    const myResult = await controller.remove(myId);
+    expect(myResult).toBeUndefined();
+  });
+});

--- a/src/crm/contollers/emails.controller.ts
+++ b/src/crm/contollers/emails.controller.ts
@@ -17,41 +17,37 @@ import { Repository } from 'typeorm';
 import SearchDto from '../../shared/dto/search.dto';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { SentryInterceptor } from 'src/utils/sentry.interceptor';
+import { EmailService } from '../emails.service';
 
 @UseInterceptors(SentryInterceptor)
 @UseGuards(JwtAuthGuard)
 @ApiTags('Crm Emails')
 @Controller('api/crm/emails')
 export class EmailsController {
-  constructor(
-    @InjectRepository(Email) private readonly repository: Repository<Email>,
-  ) {}
+  constructor(private readonly service: EmailService) {}
 
   @Get()
   async findAll(@Query() req: SearchDto): Promise<Email[]> {
-    return await this.repository.find({
-      skip: req.skip,
-      take: req.limit,
-    });
+    return await this.service.findAll(req);
   }
 
   @Post()
   async create(@Body() data: Email): Promise<Email> {
-    return await this.repository.save(data);
+    return await this.service.create(data);
   }
 
   @Put()
   async update(@Body() data: Email): Promise<Email> {
-    return await this.repository.save(data);
+    return await this.service.update(data);
   }
 
   @Get(':id')
   async findOne(@Param('id') id: number): Promise<Email> {
-    return await this.repository.findOne(id);
+    return await this.service.findOne(id);
   }
 
   @Delete(':id')
   async remove(@Param('id') id: number): Promise<void> {
-    await this.repository.delete(id);
+    await this.service.delete(id);
   }
 }

--- a/src/crm/contollers/people.controller.spec.ts
+++ b/src/crm/contollers/people.controller.spec.ts
@@ -1,0 +1,44 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import ContactListDto from '../dto/contact-list.dto';
+import { CreatePersonDto } from '../dto/create-person.dto';
+import { PersonEditDto } from '../dto/person-edit.dto';
+import Person from '../entities/person.entity';
+import { PeopleService } from '../people.service';
+import { PeopleController } from './people.controller';
+
+describe('PeopleController', () => {
+  let controller: PeopleController;
+
+  let mockPeopleService = {
+    create: jest.fn((it) => new ContactListDto()),
+    update: jest.fn((it) => new Person()),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PeopleController],
+      providers: [PeopleService],
+    })
+      .overrideProvider(PeopleService)
+      .useValue(mockPeopleService)
+      .compile();
+
+    controller = module.get<PeopleController>(PeopleController);
+  });
+
+  it('Should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('Should create a person', async () => {
+    const data: CreatePersonDto = new CreatePersonDto();
+    const result = await controller.create(data);
+    expect(result).toEqual(expect.any(ContactListDto));
+  });
+
+  it('Should update person details', async () => {
+    const data: PersonEditDto = new PersonEditDto();
+    const result = await controller.update(data);
+    expect(result).toEqual(expect.any(Person));
+  });
+});

--- a/src/crm/contollers/people.controller.ts
+++ b/src/crm/contollers/people.controller.ts
@@ -10,109 +10,37 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { ContactsService } from '../contacts.service';
-import { InjectRepository } from '@nestjs/typeorm';
 import Person from '../entities/person.entity';
-import { Like, Repository } from 'typeorm';
 import { ContactSearchDto } from '../dto/contact-search.dto';
 import { CreatePersonDto } from '../dto/create-person.dto';
-import { getPersonFullName } from '../crm.helpers';
-import { hasValue } from 'src/utils/validation';
-import { FindConditions } from 'typeorm/find-options/FindConditions';
 import { FileInterceptor } from '@nestjs/platform-express';
 import PersonListDto from '../dto/person-list.dto';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
-import { User } from '../../users/entities/user.entity';
 import ContactListDto from '../dto/contact-list.dto';
 import { PersonEditDto } from '../dto/person-edit.dto';
 import { SentryInterceptor } from 'src/utils/sentry.interceptor';
+import { PeopleService } from '../people.service';
 
 @UseInterceptors(SentryInterceptor)
 @ApiTags('Crm People')
 @Controller('api/crm/people')
 @UseGuards(JwtAuthGuard)
 export class PeopleController {
-  constructor(
-    private readonly service: ContactsService,
-    @InjectRepository(Person)
-    private readonly personRepository: Repository<Person>,
-    @InjectRepository(User)
-    private readonly userRepository: Repository<User>,
-  ) {}
+  constructor(private readonly service: PeopleService) {}
 
   @Get()
   async findAll(@Query() req: ContactSearchDto): Promise<Person[]> {
-    let q: FindConditions<Person>[] = [];
-    if (hasValue(req.query)) {
-      q = [
-        {
-          firstName: Like(`${req.query}%`),
-        },
-        {
-          middleName: Like(`${req.query}%`),
-        },
-        {
-          lastName: Like(`${req.query}%`),
-        },
-      ];
-    }
-    return await this.personRepository.find({
-      where: q,
-      skip: req.skip,
-      take: req.limit,
-    });
+    return await this.service.findAll(req);
   }
 
   @Get('combo')
   async findCombo(@Query() req: ContactSearchDto): Promise<PersonListDto[]> {
-    let q: FindConditions<Person>[] = [];
-    if (hasValue(req.query)) {
-      q = [
-        {
-          firstName: Like(`${req.query}%`),
-        },
-        {
-          middleName: Like(`${req.query}%`),
-        },
-        {
-          lastName: Like(`${req.query}%`),
-        },
-      ];
-    }
-    let data = await this.personRepository.find({
-      select: [
-        'id',
-        'firstName',
-        'lastName',
-        'middleName',
-        'avatar',
-        'contactId',
-      ],
-      where: q,
-      skip: req.skip,
-      take: req.limit,
-    });
-
-    if (req.skipUsers) {
-      const users = await this.userRepository.find({
-        where: {},
-        select: ['contactId'],
-      });
-      const idList = users.map((it) => it.contactId);
-      data = data.filter((it) => idList.indexOf(it.contactId) < 0);
-    }
-    return data.map((it) => ({
-      id: it.contactId,
-      name: getPersonFullName(it),
-      avatar: it.avatar,
-    }));
+    return await this.service.findCombo(req);
   }
 
   @Post()
   async create(@Body() data: CreatePersonDto): Promise<ContactListDto> {
-    const created = await this.service.createPerson(data);
-    const contact = await this.service.findOne(created.id);
-    return ContactsService.toListDto(contact);
+    return this.service.create(data);
   }
 
   @Post('upload')
@@ -123,14 +51,6 @@ export class PeopleController {
 
   @Put()
   async update(@Body() { id, ...data }: PersonEditDto): Promise<Person> {
-    await this.personRepository
-      .createQueryBuilder()
-      .update()
-      .set({
-        ...data,
-      })
-      .where('id = :id', { id })
-      .execute();
-    return await this.personRepository.findOne({ where: { id } });
+    return await this.service.update({ id, ...data });
   }
 }

--- a/src/crm/crm.module.ts
+++ b/src/crm/crm.module.ts
@@ -20,6 +20,7 @@ import { GroupFinderService } from './group-finder/group-finder.service';
 import { appEntities } from '../config';
 import { PhonesService } from './phones.service';
 import { AddressesService } from './addresses.service';
+import { EmailService } from './emails.service';
 
 @Global()
 @Module({
@@ -31,6 +32,7 @@ import { AddressesService } from './addresses.service';
     GroupFinderService,
     PhonesService,
     AddressesService,
+    EmailService,
   ],
   controllers: [
     ContactsController,

--- a/src/crm/crm.module.ts
+++ b/src/crm/crm.module.ts
@@ -21,6 +21,7 @@ import { appEntities } from '../config';
 import { PhonesService } from './phones.service';
 import { AddressesService } from './addresses.service';
 import { EmailService } from './emails.service';
+import { PeopleService } from './people.service';
 
 @Global()
 @Module({
@@ -33,6 +34,7 @@ import { EmailService } from './emails.service';
     PhonesService,
     AddressesService,
     EmailService,
+    PeopleService,
   ],
   controllers: [
     ContactsController,

--- a/src/crm/emails.service.ts
+++ b/src/crm/emails.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import SearchDto from "src/shared/dto/search.dto";
+import { Repository } from "typeorm";
+import Email from "./entities/email.entity";
+
+@Injectable()
+export class EmailService {
+    constructor(
+        @InjectRepository(Email) private readonly repository: Repository<Email>,
+    ){}
+
+    async create(data: Email): Promise<Email>{
+        return await this.repository.save(data);
+    }
+
+    async findAll(req: SearchDto): Promise<Email[]> {
+        return await this.repository.find({
+          skip: req.skip,
+          take: req.limit,
+        });
+      }
+    
+      async update(data: Email): Promise<Email> {
+        return await this.repository.save(data);
+      }
+    
+      async findOne(id: number): Promise<Email> {
+        return await this.repository.findOne(id);
+      }
+    
+      async delete(id: number) {
+        return await this.repository.delete(id);
+      }
+}

--- a/src/crm/people.service.ts
+++ b/src/crm/people.service.ts
@@ -1,0 +1,108 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { User } from 'src/users/entities/user.entity';
+import { hasValue } from 'src/utils/validation';
+import { FindConditions, Like, Repository } from 'typeorm';
+import { ContactsService } from './contacts.service';
+import { getPersonFullName } from './crm.helpers';
+import ContactListDto from './dto/contact-list.dto';
+import { ContactSearchDto } from './dto/contact-search.dto';
+import { CreatePersonDto } from './dto/create-person.dto';
+import { PersonEditDto } from './dto/person-edit.dto';
+import PersonListDto from './dto/person-list.dto';
+import Person from './entities/person.entity';
+
+@Injectable()
+export class PeopleService {
+  constructor(
+    @InjectRepository(Person)
+    private readonly personRepository: Repository<Person>,
+    @InjectRepository(User) private readonly userRepository: Repository<User>,
+    private readonly service: ContactsService,
+  ) {}
+
+  async findAll(req: ContactSearchDto): Promise<Person[]> {
+    let q: FindConditions<Person>[] = [];
+    if (hasValue(req.query)) {
+      q = [
+        {
+          firstName: Like(`${req.query}%`),
+        },
+        {
+          middleName: Like(`${req.query}%`),
+        },
+        {
+          lastName: Like(`${req.query}%`),
+        },
+      ];
+    }
+    return await this.personRepository.find({
+      where: q,
+      skip: req.skip,
+      take: req.limit,
+    });
+  }
+
+  async findCombo(req: ContactSearchDto): Promise<PersonListDto[]> {
+    let q: FindConditions<Person>[] = [];
+    if (hasValue(req.query)) {
+      q = [
+        {
+          firstName: Like(`${req.query}%`),
+        },
+        {
+          middleName: Like(`${req.query}%`),
+        },
+        {
+          lastName: Like(`${req.query}%`),
+        },
+      ];
+    }
+    let data = await this.personRepository.find({
+      select: [
+        'id',
+        'firstName',
+        'lastName',
+        'middleName',
+        'avatar',
+        'contactId',
+      ],
+      where: q,
+      skip: req.skip,
+      take: req.limit,
+    });
+
+    if (req.skipUsers) {
+      const users = await this.userRepository.find({
+        where: {},
+        select: ['contactId'],
+      });
+      const idList = users.map((it) => it.contactId);
+      data = data.filter((it) => idList.indexOf(it.contactId) < 0);
+    }
+    return data.map((it) => ({
+      id: it.contactId,
+      name: getPersonFullName(it),
+      avatar: it.avatar,
+    }));
+  }
+
+  async create(data: CreatePersonDto): Promise<ContactListDto> {
+    const created = await this.service.createPerson(data);
+    const contact = await this.service.findOne(created.id);
+    return ContactsService.toListDto(contact);
+  }
+
+  async update({ id, ...data }: PersonEditDto): Promise<Person> {
+    await this.personRepository
+      .createQueryBuilder()
+      .update()
+      .set({
+        ...data,
+      })
+      .where('id = :id', { id })
+      .execute();
+
+    return await this.personRepository.findOne({ where: { id } });
+  }
+}

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -20,7 +20,7 @@ const hashCost = 10;
 @Entity()
 @Unique(['username'])
 export class User {
-  @PrimaryGeneratedColumn()
+  @PrimaryColumn()
   id: number;
 
   @Column({ length: 40 })


### PR DESCRIPTION
# Ticket No
- #94 

# Summary of changes
- Created `EmailService`, `PeopleService` and `AddressesService`.
- Added CRUD methods to handle requests from the respective endpoints
- Added tests for email, addresses and people

# How should this be tested? [Screenshots, Video or Type instructions]
- Performing any of the available CRUD operations from the user profile should work with no issues on email, person and addresses.
- Changed the id of User entity from `PrimaryGeneratedColumn` to `PrimaryColumn` for user related operations to work properly.
- All tests should pass

![image](https://user-images.githubusercontent.com/5897163/129625379-6cadb544-18e7-473f-a009-9647563b17ec.png)


# Notes for reviewers
- N/A

# Out of scope
-  N/A

