### PR TITLE
Created group permissions service

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,3 @@
+export const TENANT_HEADER = "tenant";
+export const TENANT_NAME_FIELD = "churchName";
+export const DEFAULT_TENANT = "default";

--- a/src/groups/controllers/group-combo.controller.ts
+++ b/src/groups/controllers/group-combo.controller.ts
@@ -1,18 +1,31 @@
-import { Controller, Get, Query, UseInterceptors } from '@nestjs/common';
-import { GroupsService } from '../services/groups.service';
-import Group from '../entities/group.entity';
-import { ApiTags } from '@nestjs/swagger';
-import { GroupSearchDto } from '../dto/group-search.dto';
-import { SentryInterceptor } from 'src/utils/sentry.interceptor';
+import {
+  Controller,
+  Get,
+  Query,
+  Request,
+  UseGuards,
+  UseInterceptors,
+} from "@nestjs/common";
+import { GroupsService } from "../services/groups.service";
+import Group from "../entities/group.entity";
+import { ApiTags } from "@nestjs/swagger";
+import { GroupSearchDto } from "../dto/group-search.dto";
+import { SentryInterceptor } from "src/utils/sentry.interceptor";
+import { JwtAuthGuard } from "../../auth/guards/jwt-auth.guard";
 
 @UseInterceptors(SentryInterceptor)
-@ApiTags('Groups Combo')
-@Controller('api/groups/combo')
+@UseGuards(JwtAuthGuard)
+@ApiTags("Groups Combo")
+@Controller("api/groups/combo")
 export class GroupComboController {
   constructor(private readonly service: GroupsService) {}
 
   @Get()
-  async combo(@Query() req: GroupSearchDto): Promise<Group[]> {
-    return this.service.combo(req);
+  async combo(
+    @Query() req: GroupSearchDto,
+    @Request() rawRequest: any,
+  ): Promise<Group[]> {
+    console.log("combo>>>>", rawRequest.user);
+    return this.service.combo(req, rawRequest.user);
   }
 }

--- a/src/groups/controllers/group.controller.ts
+++ b/src/groups/controllers/group.controller.ts
@@ -9,46 +9,58 @@ import {
   Query,
   UseGuards,
   UseInterceptors,
-} from '@nestjs/common';
-import { GroupsService } from '../services/groups.service';
-import SearchDto from '../../shared/dto/search.dto';
-import { ApiTags } from '@nestjs/swagger';
-import GroupListDto from '../dto/group-list.dto';
-import CreateGroupDto from '../dto/create-group.dto';
-import UpdateGroupDto from '../dto/update-group.dto';
-import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
-import { SentryInterceptor } from './../../utils/sentry.interceptor';
+  Request,
+} from "@nestjs/common";
+import { GroupsService } from "../services/groups.service";
+import SearchDto from "../../shared/dto/search.dto";
+import { ApiTags } from "@nestjs/swagger";
+import GroupListDto from "../dto/group-list.dto";
+import CreateGroupDto from "../dto/create-group.dto";
+import UpdateGroupDto from "../dto/update-group.dto";
+import { JwtAuthGuard } from "../../auth/guards/jwt-auth.guard";
+import { SentryInterceptor } from "../../utils/sentry.interceptor";
 
 @UseInterceptors(SentryInterceptor)
 @UseGuards(JwtAuthGuard)
-@ApiTags('Groups')
-@Controller('api/groups/group')
+@ApiTags("Groups")
+@Controller("api/groups/group")
 export class GroupController {
-  constructor(private readonly service: GroupsService) {
-  }
+  constructor(private readonly service: GroupsService) {}
 
   @Get()
-  async findAll(@Query() req: SearchDto): Promise<GroupListDto[]> {
+  async findAll(
+    @Query() req: SearchDto,
+    @Request() rawRequest: any,
+  ): Promise<GroupListDto[]> {
     return this.service.findAll(req);
   }
 
   @Post()
-  async create(@Body()data: CreateGroupDto): Promise<GroupListDto> {
-    return await this.service.create(data);
+  async create(
+    @Body() data: CreateGroupDto,
+    @Request() rawRequest: any,
+  ): Promise<GroupListDto> {
+    return await this.service.create(data, rawRequest.user);
   }
 
   @Put()
-  async update(@Body()data: UpdateGroupDto): Promise<GroupListDto> {
-    return await this.service.update(data);
+  async update(
+    @Body() data: UpdateGroupDto,
+    @Request() rawRequest: any,
+  ): Promise<GroupListDto> {
+    return await this.service.update(data, rawRequest.user);
   }
 
-  @Get(':id')
-  async findOne(@Param('id') id: number): Promise<GroupListDto> {
+  @Get(":id")
+  async findOne(@Param("id") id: number): Promise<GroupListDto> {
     return await this.service.findOne(id);
   }
 
-  @Delete(':id')
-  async remove(@Param('id') id: number): Promise<void> {
-    await this.service.remove(id);
+  @Delete(":id")
+  async remove(
+    @Param("id") id: number,
+    @Request() rawRequest: any,
+  ): Promise<void> {
+    await this.service.remove(id, rawRequest.user);
   }
 }

--- a/src/groups/groups.module.ts
+++ b/src/groups/groups.module.ts
@@ -1,4 +1,4 @@
-import { HttpModule, Module, MiddlewareConsumer } from "@nestjs/common";
+import { HttpModule, Module } from "@nestjs/common";
 import { GroupsService } from "./services/groups.service";
 import { GroupCategoriesService } from "./services/group-categories.service";
 import { GroupController } from "./controllers/group.controller";
@@ -19,8 +19,8 @@ import { GroupMissingReportsService } from "./services/group-missing-reports.ser
 import { GroupReportsController } from "./controllers/group-reports.controller";
 import { GroupReportFrequencyController } from "./controllers/group-frequency.controller";
 import { GroupCategoryComboController } from "./controllers/group-category-combo.controller";
-import { nameTenantHeaderMiddleware } from "src/middleware/nameTenantHeader.middleware";
 import { AddressesService } from "src/crm/addresses.service";
+import { GroupPermissionsService } from "./services/group-permissions.service";
 
 @Module({
   imports: [
@@ -39,6 +39,7 @@ import { AddressesService } from "src/crm/addresses.service";
     PrismaService,
     EventsService,
     GroupMissingReportsService,
+    GroupPermissionsService,
   ],
   controllers: [
     GroupController,
@@ -50,6 +51,6 @@ import { AddressesService } from "src/crm/addresses.service";
     GroupReportFrequencyController,
     GroupCategoryComboController,
   ],
-  exports: [GroupsService, GroupCategoriesService],
+  exports: [GroupsService, GroupCategoriesService, GroupPermissionsService],
 })
 export class GroupsModule {}

--- a/src/groups/services/group-membership.service.ts
+++ b/src/groups/services/group-membership.service.ts
@@ -11,7 +11,6 @@ import BatchGroupMembershipDto from "../dto/membership/batch-group-membership.dt
 import { QueryDeepPartialEntity } from "typeorm/query-builder/QueryPartialEntity";
 import { hasNoValue, hasValue } from "../../utils/validation";
 import Group from "../entities/group.entity";
-import { groupConstants } from "../../seed/data/groups";
 
 @Injectable()
 export class GroupsMembershipService {

--- a/src/groups/services/group-permissions.service.ts
+++ b/src/groups/services/group-permissions.service.ts
@@ -1,0 +1,66 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { Connection, In, Repository, TreeRepository } from "typeorm";
+import Group from "../entities/group.entity";
+import GroupMembership from "../entities/groupMembership.entity";
+import { GroupRole } from "../enums/groupRole";
+import ClientFriendlyException from "../../shared/exceptions/client-friendly.exception";
+
+@Injectable()
+export class GroupPermissionsService {
+  private readonly repository: Repository<Group>;
+  private readonly treeRepository: TreeRepository<Group>;
+  private readonly membershipRepository: Repository<GroupMembership>;
+
+  constructor(@Inject("CONNECTION") connection: Connection) {
+    this.repository = connection.getRepository(Group);
+    this.treeRepository = connection.getTreeRepository(Group);
+    this.membershipRepository = connection.getRepository(GroupMembership);
+  }
+
+  async hasPermissionForGroup(user: any, groupId: number) {
+    const ancestors = await this.treeRepository.findAncestors({
+      id: groupId,
+    } as Group);
+    const ancestorsIds = [groupId, ...ancestors.map((it) => it.id)];
+    const result = await this.membershipRepository.count({
+      where: {
+        contactId: user.contactId,
+        role: GroupRole.Leader,
+        groupId: In(ancestorsIds),
+      },
+    });
+    return result >= 1;
+  }
+
+  // Is leader of group or one of the ancestors
+  async assertPermissionForGroup(user: any, groupId: number) {
+    const hasPerms = await this.hasPermissionForGroup(user, groupId);
+    if (!hasPerms) {
+      throw new ClientFriendlyException(
+        `You have no permissions to modify this group`,
+      );
+    }
+  }
+
+  async getUserGroupIds(user: any) {
+    const membershipData = await this.membershipRepository.find({
+      select: ["groupId"],
+      where: {
+        contactId: user.contactId,
+        role: GroupRole.Leader,
+      },
+    });
+    const descendants = [];
+    for (const mData of membershipData) {
+      const res = await this.treeRepository.findDescendants({
+        id: mData.groupId,
+      } as Group);
+      descendants.push(...res);
+    }
+    const idList = new Set([
+      ...membershipData.map((it) => it.groupId),
+      ...descendants.map((it) => it.id),
+    ]);
+    return Array.from(idList);
+  }
+}

--- a/src/middleware/nameTenantHeader.middleware.ts
+++ b/src/middleware/nameTenantHeader.middleware.ts
@@ -1,5 +1,7 @@
 import { Injectable, Logger, NestMiddleware } from "@nestjs/common";
 import { lowerCaseRemoveSpaces } from "src/utils/stringHelpers";
+import { TENANT_NAME_FIELD, TENANT_HEADER } from "../constants";
+import { hasNoValue } from "../utils/validation";
 
 /**
  * From the churchName field in the body of the request,
@@ -8,12 +10,19 @@ import { lowerCaseRemoveSpaces } from "src/utils/stringHelpers";
 @Injectable()
 export class nameTenantHeaderMiddleware implements NestMiddleware {
   use(req: any, res: any, next: () => void) {
-    const churchName = req.body.hasOwnProperty("churchName")
-      ? req.body["churchName"]
-      : req.query["churchName"];
-    const tenant = lowerCaseRemoveSpaces(churchName);
-    req.headers.tenant = tenant;
-    Logger.log(`New request received from church: ${tenant}`);
+    Logger.log(`running middleware: ${req.headers[TENANT_HEADER]}`);
+    if (hasNoValue(req.headers[TENANT_HEADER])) {
+      const churchName = req.body.hasOwnProperty(TENANT_NAME_FIELD)
+        ? req.body[TENANT_NAME_FIELD]
+        : req.query[TENANT_NAME_FIELD];
+      const tenant = lowerCaseRemoveSpaces(churchName);
+      req.headers[TENANT_HEADER] = tenant;
+      Logger.log(`New request received from church: ${tenant}`);
+    } else {
+      Logger.log(
+        `New request received from church: ${req.headers[TENANT_HEADER]}`,
+      );
+    }
     next();
   }
 }

--- a/src/seed/seed.service.ts
+++ b/src/seed/seed.service.ts
@@ -68,7 +68,7 @@ export class SeedService {
       Logger.debug(`${count} Groups already exist`);
     } else {
       for (const rec of seedGroups) {
-        await this.groupsService.create(rec);
+        await this.groupsService.create(rec, {});
       }
     }
   }

--- a/src/tenants/tenants.module.ts
+++ b/src/tenants/tenants.module.ts
@@ -5,22 +5,21 @@ import {
   BadRequestException,
   MiddlewareConsumer,
 } from "@nestjs/common";
-import { getConnectionManager, createConnection } from "typeorm";
 import { REQUEST } from "@nestjs/core";
-import config, { appEntities } from "../config";
 import { TenantsController } from "./tenants.controller";
 import { TenantsService } from "./tenants.service";
-import * as dotenv from "dotenv";
 import { DbService } from "src/shared/db.service";
 import { SeedModule } from "src/seed/seed.module";
 import { Tenant } from "./entities/tenant.entity";
 import { nameTenantHeaderMiddleware } from "src/middleware/nameTenantHeader.middleware";
+import { TENANT_HEADER } from "../constants";
 
 const connectionFactory = {
   provide: "CONNECTION",
   scope: Scope.REQUEST,
   useFactory: async (req: any, dbservice: DbService) => {
-    const tenantName = req.headers["tenant"];
+    console.log("req.headers", req.headers);
+    const tenantName = req.headers[TENANT_HEADER];
     const connectionPublic = await dbservice.getConnection();
     const isCreatingNewTenant =
       req.originalUrl == "/api/tenants" && req.method == "POST";

--- a/src/tenants/tenants.module.ts
+++ b/src/tenants/tenants.module.ts
@@ -18,7 +18,6 @@ const connectionFactory = {
   provide: "CONNECTION",
   scope: Scope.REQUEST,
   useFactory: async (req: any, dbservice: DbService) => {
-    console.log("req.headers", req.headers);
     const tenantName = req.headers[TENANT_HEADER];
     const connectionPublic = await dbservice.getConnection();
     const isCreatingNewTenant =

--- a/src/tenants/tenants.service.ts
+++ b/src/tenants/tenants.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, Logger } from "@nestjs/common";
 import { DbService } from "src/shared/db.service";
 import { Tenant } from "./entities/tenant.entity";
 import { TenantDto } from "./dto/tenant.dto";
@@ -23,7 +23,10 @@ export class TenantsService {
 
   async seed(tenantData: TenantDto): Promise<string> {
     if (tenantData.seed) {
+      Logger.log("seeding database");
       await this.seedService.createAll();
+    } else {
+      Logger.log("skip seeding database");
     }
     return "Successfully seeded the tenant";
   }

--- a/src/utils/stringHelpers.ts
+++ b/src/utils/stringHelpers.ts
@@ -1,3 +1,3 @@
 export const lowerCaseRemoveSpaces = (name: string): string => {
-  return name.toLowerCase().replace(/\s/g, "");
+  return name?.toLowerCase().replace(/\s/g, "");
 };


### PR DESCRIPTION
# Ticket No
https://trello.com/c/QupjHF6b/3-group-level-access-restrictions

# Summary of changes
Added restrictions in place that can ensure that members have access only to group levels relevant to their roles.
I created a `GroupPermissionsService` that encapsulates most of the logic around group permissions. 

# How should this be tested? [Screenshots, Video, or Type instructions]
- While logged in, assign yourself a role leader to the the topmost group. Then go to the dashboard
- You should be able to see all groups show up in the drop-down
- Remove the role of Leader from the the top-level group, then assign yourself a lower group, while on the dashboard, you should only see the groups under the newly assigned group.
Other tests
- While on the group list, You should not be able to edit a group for which you are not a leader.

# Notes for reviewers
- I was not able to get the linting to work,

# Out of scope
-  Group reports

